### PR TITLE
Protect active user list with mutex

### DIFF
--- a/internal/honeypot/model.go
+++ b/internal/honeypot/model.go
@@ -117,9 +117,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case filesystem.OutputMsg:
 		m.output += m.outputStyle.Render("\n" + string(msg) + "\n")
 	case filesystem.ListActiveUsersMsg:
-		m.output += fmt.Sprintf("04:25:58 up 10 days, 23:21,  %d users,  load average: 0.10, 0.18, 0.10\n", len(activeUsers))
+		users := activeUsersSnapshot()
+		m.output += fmt.Sprintf("04:25:58 up 10 days, 23:21,  %d users,  load average: 0.10, 0.18, 0.10\n", len(users))
 		m.output += fmt.Sprintf("%s\t%s\t%s\t%s\t%s\t%s\t%s\n", "USER", "TTY", "FROM", "LOGIN@", "IDLE", "JCPU", "PCPU WHAT")
-		for i, u := range activeUsers {
+		for i, u := range users {
 			m.output += fmt.Sprintf("%s\tpts/%d\t%s\t%s\t%s\t%s\t%s\n", u, i, "--", "--", "--", "--", "--")
 		}
 	case filesystem.ClearOutputMsg:

--- a/internal/honeypot/stats.go
+++ b/internal/honeypot/stats.go
@@ -13,11 +13,11 @@ var (
 )
 
 func StatActiveUsers() int {
-	return len(activeUsers)
+	return activeUsersLen()
 }
 
 func StatUsersThisSession() int {
-	return usersThisSession
+	return usersThisSessionCount()
 }
 
 func StatUsersAllTime() int {


### PR DESCRIPTION
## Summary
- synchronize access to `activeUsers` and `usersThisSession` with a mutex
- snapshot active users when listing them in the TUI
- expose thread-safe statistics helpers

## Testing
- `go vet ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6847e14fb0b88324ad1139724e392162