### PR TITLE
Add runtime config file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ The honeypot can be configured using command-line flags when starting the applic
 - `-ssh-port`: The port(s) to listen on for honey pot SSH connections (comma separated for multiple ports, default "1337")
 - `-tunnel`: Set up SSH reverse tunnel (format: user@server.com:22)
 - `-tunnel-key`: Path to SSH key for reverse tunnel authentication
+- `-config`: Path to a JSON configuration file with the same options
+
+The configuration file can also define additional settings like extra filesystem nodes or CTF tasks. See `misc/config.sample.json` for an example.
 
 ## Usage
 
@@ -59,6 +62,8 @@ To run the application locally, you will need to have Go installed on your machi
 $ go run main.go -h
 
 Usage of /***/main
+  -config string
+        Path to optional JSON configuration file
   -fs
         Start the gui in full screen mode
   -height int

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,17 +1,39 @@
 package config
 
-var defaults = map[string]string{
-	"pot_host": "localhost",
-	"pot_port": "2222",
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/mikeflynn/honeybearhoneypot/internal/honeypot/filesystem"
+)
+
+type Task struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Flag        string `json:"flag"`
 }
 
-func GetValue(name string) string {
-	// Check if the key exists in the map
+type Config struct {
+	SSHPorts   []string          `json:"ssh_ports,omitempty"`
+	Tunnel     string            `json:"tunnel,omitempty"`
+	TunnelKey  string            `json:"tunnel_key,omitempty"`
+	NoGUI      bool              `json:"no_gui,omitempty"`
+	FullScreen bool              `json:"full_screen,omitempty"`
+	Width      int               `json:"width,omitempty"`
+	Height     int               `json:"height,omitempty"`
+	LogLevel   string            `json:"log_level,omitempty"`
+	Filesystem []filesystem.Node `json:"filesystem,omitempty"`
+	Tasks      []Task            `json:"tasks,omitempty"`
+}
 
-	// If not, check in the defaults map
-	if val, ok := defaults[name]; ok {
-		return val
+func Load(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
 	}
-
-	return ""
+	var c Config
+	if err := json.Unmarshal(data, &c); err != nil {
+		return nil, err
+	}
+	return &c, nil
 }

--- a/misc/config.sample.json
+++ b/misc/config.sample.json
@@ -1,0 +1,24 @@
+{
+  "ssh_ports": ["1337"],
+  "log_level": "info",
+  "tunnel": "",
+  "tunnel_key": "",
+  "no_gui": false,
+  "full_screen": false,
+  "width": 0,
+  "height": 0,
+  "filesystem": [
+    {
+      "Name": "extra",
+      "Path": "/opt/extra",
+      "Directory": true
+    }
+  ],
+  "tasks": [
+    {
+      "name": "demo",
+      "description": "Example flag",
+      "flag": "flag{demo}"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add Config struct and Load function
- add `-config` flag to load settings from JSON
- mention new flag and options in README
- provide sample config
- refine struct with filesystem nodes and single-flag tasks
- restore Name field for config.Task

## Testing
- `go vet ./...` *(fails: Get "https://proxy.golang.org/..." Forbidden)*
- `go test ./...` *(fails: Get "https://proxy.golang.org/..." Forbidden)*
- `go build ./...` *(fails: Get "https://proxy.golang.org/..." Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68491afd343c83248cb8c017f372e339