### PR TITLE
Support custom filesystem nodes

### DIFF
--- a/internal/honeypot/filesystem/extra.go
+++ b/internal/honeypot/filesystem/extra.go
@@ -1,0 +1,61 @@
+package filesystem
+
+import (
+	"errors"
+	"path"
+	"strings"
+)
+
+var additionalNodes []Node
+
+// SetAdditionalNodes stores nodes that will be merged into the filesystem
+// during initialization.
+func SetAdditionalNodes(nodes []Node) {
+	additionalNodes = nodes
+}
+
+// addNode inserts a node into the filesystem tree under its parent path.
+// Parent directories must already exist.
+func addNode(n Node) error {
+	if SystemRoot == nil {
+		return errors.New("filesystem not initialized")
+	}
+	if n.Path == "" {
+		return errors.New("node path required")
+	}
+
+	if n.Name == "" {
+		n.Name = path.Base(n.Path)
+	}
+	parentPath := path.Dir(n.Path)
+	if parentPath == "." {
+		parentPath = "/"
+	}
+	parent, err := GetNodeByPath(SystemRoot, strings.TrimPrefix(parentPath, "/"))
+	if err != nil {
+		return err
+	}
+
+	if n.Owner == "" {
+		n.Owner = "root"
+	}
+	if n.Group == "" {
+		n.Group = "root"
+	}
+	if n.Mode == 0 {
+		if n.Directory {
+			n.Mode = 0755
+		} else {
+			n.Mode = 0644
+		}
+	}
+
+	parent.Children = append(parent.Children, &n)
+	return nil
+}
+
+func applyAdditionalNodes() {
+	for _, n := range additionalNodes {
+		_ = addNode(n)
+	}
+}

--- a/internal/honeypot/filesystem/filesystem.go
+++ b/internal/honeypot/filesystem/filesystem.go
@@ -566,4 +566,6 @@ func Initialize() {
 		Owner: "root",
 		Group: "root",
 	}
+
+	applyAdditionalNodes()
 }

--- a/internal/honeypot/filesystem/node.go
+++ b/internal/honeypot/filesystem/node.go
@@ -105,17 +105,18 @@ func RunNode(currentNode *Node, path string, params []string, user string, group
 }
 
 type Node struct {
-	Name      string
-	Path      string
-	Directory bool
-	Children  []*Node
-	AssetName string
-	Content   func() []byte
-	Exec      func(*Node, []string) *tea.Cmd
-	Owner     string
-	Group     string
-	Mode      int
-	HelpText  string
+	Name        string                         `json:"name"`
+	Path        string                         `json:"path"`
+	Directory   bool                           `json:"directory"`
+	Children    []*Node                        `json:"-"`                      // Children nodes, if applicable
+	AssetName   string                         `json:"asset_name,omitempty"`   // Only set if Directory is false
+	Content     func() []byte                  `json:"-"`                      // Function to get the content of the file, if applicable
+	ContentText string                         `json:"content_text,omitempty"` // Text content of the file, if applicable
+	Exec        func(*Node, []string) *tea.Cmd `json:"-"`                      // Function to execute the node, if applicable
+	Owner       string                         `json:"owner"`
+	Group       string                         `json:"group"`
+	Mode        int                            `json:"mode"`                // File mode (permissions)
+	HelpText    string                         `json:"help_text,omitempty"` // Help text for the node, if applicable
 }
 
 func (n *Node) IsDirectory() bool {
@@ -202,6 +203,8 @@ func (n *Node) Child(name string) *Node {
 func (n *Node) Open() ([]byte, error) {
 	if n.IsFile() && n.Content != nil {
 		return n.Content(), nil
+	} else if n.IsFile() && n.ContentText != "" {
+		return []byte(n.ContentText), nil
 	}
 
 	return nil, errors.New("not a file")

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mikeflynn/honeybearhoneypot/internal/entity"
 	"github.com/mikeflynn/honeybearhoneypot/internal/gui"
 	"github.com/mikeflynn/honeybearhoneypot/internal/honeypot"
+	"github.com/mikeflynn/honeybearhoneypot/internal/honeypot/filesystem"
 )
 
 const (
@@ -24,6 +25,8 @@ func main() {
 	if err != nil {
 		log.Fatal("Failed to parse configuration", "error", err)
 	}
+
+	filesystem.SetAdditionalNodes(cfg.Filesystem)
 
 	log.SetLevel(translateLogLevel(cfg.LogLevel))
 	log.Info("Starting Honey Bear Honey Pot...")


### PR DESCRIPTION
## Summary
- allow config.json to supply additional filesystem nodes
- merge these nodes into the honeypot filesystem at init
- hook up main to forward nodes from configuration

## Testing
- `go test ./...` *(fails: proxy access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6857462620c88324a4603779c7f57845