### PR TITLE
Improve CTF login UX and styling

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -18,7 +18,8 @@
     {
       "name": "demo",
       "description": "Example flag",
-      "flag": "flag{demo}"
+      "flag": "flag{demo}",
+      "points": 100
     }
   ]
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ type Task struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
 	Flag        string `json:"flag"`
+	Points      int    `json:"points"`
 }
 
 type Config struct {
@@ -41,6 +42,10 @@ var (
 	tunnelHost    = flag.String("tunnel", "", "The user and host to connect to via SSH. Ex: user@server.com:22")
 	tunnelKeyFlag = flag.String("tunnel-key", "", "The SSH key to use to connect to the specified remote host.")
 )
+
+// Active holds the configuration loaded via Parse so it can be referenced by
+// other packages at runtime.
+var Active *Config
 
 // Default contains the base configuration values used when no CLI flags or config file options are provided.
 var Default = Config{
@@ -102,7 +107,8 @@ func Parse() (*Config, string, error) {
 
 	cfg.PinReset = *pinResetFlag
 
-	return &cfg, cfg.PinReset, nil
+	Active = &cfg
+	return Active, cfg.PinReset, nil
 }
 
 func merge(dst *Config, src *Config) {

--- a/internal/entity/ctf_user.go
+++ b/internal/entity/ctf_user.go
@@ -1,0 +1,91 @@
+package entity
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/mikeflynn/honeybearhoneypot/internal/db"
+)
+
+const CTFUserInit = `
+CREATE TABLE IF NOT EXISTS ctf_users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT UNIQUE,
+    password TEXT,
+    points INTEGER DEFAULT 0,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+`
+
+const CTFUserTaskInit = `
+CREATE TABLE IF NOT EXISTS ctf_user_tasks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    username TEXT NOT NULL,
+    task TEXT NOT NULL,
+    points INTEGER NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(username, task)
+);
+`
+
+type CTFUser struct {
+	ID        int
+	Username  string
+	Password  string
+	Points    int
+	CreatedAt time.Time
+}
+
+type CTFUserTask struct {
+	ID        int
+	Username  string
+	Task      string
+	Points    int
+	CreatedAt time.Time
+}
+
+func (u *CTFUser) Load() error {
+	if u.Username == "" {
+		return fmt.Errorf("username required")
+	}
+	row, err := db.MakeQuery("SELECT id, username, password, points, created_at FROM ctf_users WHERE username = ?", u.Username)
+	if err != nil {
+		return err
+	}
+	defer row.Close()
+	if row.Next() {
+		return row.Scan(&u.ID, &u.Username, &u.Password, &u.Points, &u.CreatedAt)
+	}
+	return fmt.Errorf("user not found")
+}
+
+func (u *CTFUser) Save() error {
+	query := `INSERT INTO ctf_users (username, password, points) VALUES (?, ?, ?) ON CONFLICT(username) DO UPDATE SET password=excluded.password, points=excluded.points`
+	return db.MakeWrite(query, u.Username, u.Password, u.Points)
+}
+
+func (u *CTFUser) AddPoints(p int) error {
+	u.Points += p
+	return db.MakeWrite("UPDATE ctf_users SET points=? WHERE username=?", u.Points, u.Username)
+}
+
+func (u *CTFUser) CompleteTask(task string, points int) error {
+	if u.Username == "" {
+		return fmt.Errorf("username required")
+	}
+
+	rows, err := db.MakeQuery("SELECT 1 FROM ctf_user_tasks WHERE username=? AND task=?", u.Username, task)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	if rows.Next() {
+		return fmt.Errorf("task already completed")
+	}
+
+	if err := db.MakeWrite("INSERT INTO ctf_user_tasks (username, task, points) VALUES (?, ?, ?)", u.Username, task, points); err != nil {
+		return err
+	}
+
+	return u.AddPoints(points)
+}

--- a/internal/honeypot/ctf/ctf.go
+++ b/internal/honeypot/ctf/ctf.go
@@ -1,0 +1,256 @@
+package ctf
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/list"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/mikeflynn/honeybearhoneypot/internal/entity"
+)
+
+// Start returns a tea.Msg used to launch the CTF game.
+func Start() tea.Msg { return startMsg{} }
+
+// startMsg is used to bootstrap the game from the filesystem command.
+type startMsg struct{}
+
+// gameState indicates which screen we're showing.
+type gameState int
+
+const (
+	stateLogin gameState = iota
+	stateMenu
+	stateAnswer
+	stateDone
+)
+
+type Task struct {
+	Name        string
+	Description string
+	Flag        string
+	Points      int
+}
+
+type item struct {
+	task Task
+}
+
+func (i item) Title() string       { return i.task.Name }
+func (i item) Description() string { return i.task.Description }
+func (i item) FilterValue() string { return i.task.Name }
+
+type Model struct {
+	state    gameState
+	username string
+	password string
+	user     *entity.CTFUser
+
+	usernameInput textinput.Model
+	passwordInput textinput.Model
+	answerInput   textinput.Model
+
+	list list.Model
+
+	selectedTask *Task
+
+	errMsg string
+}
+
+var (
+	titleStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("205")).Bold(true)
+	errorStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("1"))
+)
+
+func InitialModel(tasks []Task) Model {
+	ti := textinput.New()
+	ti.Placeholder = "username"
+	ti.Focus()
+	ti.CharLimit = 32
+
+	pi := textinput.New()
+	pi.Placeholder = "password"
+	pi.CharLimit = 32
+	pi.EchoMode = textinput.EchoPassword
+
+	ai := textinput.New()
+	ai.Placeholder = "flag"
+	ai.CharLimit = 256
+
+	items := []list.Item{}
+	for _, t := range tasks {
+		items = append(items, item{task: t})
+	}
+	l := list.New(items, list.NewDefaultDelegate(), 0, 0)
+	l.Title = "Challenges"
+	l.SetShowStatusBar(false)
+	l.SetFilteringEnabled(false)
+
+	return Model{
+		state:         stateLogin,
+		usernameInput: ti,
+		passwordInput: pi,
+		answerInput:   ai,
+		list:          l,
+	}
+}
+
+func (m Model) Init() tea.Cmd { return nil }
+
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg.(type) {
+	case startMsg:
+		return m, nil
+	}
+
+	switch m.state {
+	case stateLogin:
+		return m.updateLogin(msg)
+	case stateMenu:
+		return m.updateMenu(msg)
+	case stateAnswer:
+		return m.updateAnswer(msg)
+	case stateDone:
+		return m, tea.Quit
+	}
+	return m, nil
+}
+
+func (m *Model) authenticate() tea.Cmd {
+	u := &entity.CTFUser{Username: m.usernameInput.Value()}
+	err := u.Load()
+	if err != nil {
+		// create
+		u.Username = m.usernameInput.Value()
+		u.Password = m.passwordInput.Value()
+		if err := u.Save(); err != nil {
+			m.errMsg = err.Error()
+			return nil
+		}
+	}
+	if u.Password != m.passwordInput.Value() {
+		m.errMsg = "invalid password"
+		return nil
+	}
+	m.user = u
+	m.username = u.Username
+	m.password = u.Password
+	m.state = stateMenu
+	m.errMsg = ""
+	return nil
+}
+
+func (m Model) updateLogin(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "enter":
+			if m.usernameInput.Focused() {
+				m.usernameInput.Blur()
+				m.passwordInput.Focus()
+				return m, nil
+			}
+			if m.passwordInput.Focused() {
+				return m, m.authenticate()
+			}
+		case "tab", "shift+tab", "down", "up":
+			if m.usernameInput.Focused() {
+				m.usernameInput.Blur()
+				m.passwordInput.Focus()
+			} else {
+				m.passwordInput.Blur()
+				m.usernameInput.Focus()
+			}
+			return m, nil
+		}
+	}
+	if m.usernameInput.Focused() {
+		m.usernameInput, cmd = m.usernameInput.Update(msg)
+	} else {
+		m.passwordInput, cmd = m.passwordInput.Update(msg)
+	}
+	return m, cmd
+}
+
+func (m Model) updateMenu(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "enter":
+			if it, ok := m.list.SelectedItem().(item); ok {
+				m.selectedTask = &it.task
+				m.state = stateAnswer
+				m.answerInput.SetValue("")
+				m.answerInput.Focus()
+			}
+			return m, nil
+		case "q", "ctrl+c":
+			m.state = stateDone
+			return m, tea.Quit
+		}
+	}
+	m.list, cmd = m.list.Update(msg)
+	return m, cmd
+}
+
+func (m Model) updateAnswer(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "enter":
+			ans := strings.TrimSpace(m.answerInput.Value())
+			if ans == m.selectedTask.Flag {
+				if err := m.user.CompleteTask(m.selectedTask.Name, m.selectedTask.Points); err != nil {
+					m.errMsg = err.Error()
+				} else {
+					m.errMsg = fmt.Sprintf("Correct! +%d points", m.selectedTask.Points)
+				}
+			} else {
+				m.errMsg = "Incorrect flag"
+			}
+			m.state = stateMenu
+			return m, nil
+		case "esc":
+			m.state = stateMenu
+			return m, nil
+		}
+	}
+	m.answerInput, cmd = m.answerInput.Update(msg)
+	return m, cmd
+}
+
+func (m Model) View() string {
+	switch m.state {
+	case stateLogin:
+		return lipgloss.JoinVertical(lipgloss.Left,
+			titleStyle.Render("Honey Bear Honey Pot CTF"),
+			errorStyle.Render(m.errMsg),
+			"username: "+m.usernameInput.View(),
+			"password: "+m.passwordInput.View(),
+			"",
+			"Press enter to switch fields and submit",
+		)
+	case stateMenu:
+		header := fmt.Sprintf("Honey Bear Honey Pot CTF - %s (%d pts)", m.user.Username, m.user.Points)
+		m.list.Title = titleStyle.Render(header)
+		return lipgloss.JoinVertical(lipgloss.Left,
+			m.list.View(),
+			errorStyle.Render(m.errMsg),
+		)
+	case stateAnswer:
+		return lipgloss.JoinVertical(lipgloss.Left,
+			titleStyle.Render(m.selectedTask.Name),
+			m.selectedTask.Description,
+			m.answerInput.View(),
+			errorStyle.Render(m.errMsg),
+		)
+	case stateDone:
+		return "Goodbye"
+	}
+	return ""
+}

--- a/internal/honeypot/filesystem/filesystem.go
+++ b/internal/honeypot/filesystem/filesystem.go
@@ -7,6 +7,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/mikeflynn/honeybearhoneypot/internal/honeypot/confetti"
+	"github.com/mikeflynn/honeybearhoneypot/internal/honeypot/ctf"
 	"github.com/mikeflynn/honeybearhoneypot/internal/honeypot/embedded"
 	"github.com/mikeflynn/honeybearhoneypot/internal/honeypot/matrix"
 )
@@ -412,6 +413,25 @@ func Initialize() {
 										return matrix.Start()
 									}))
 
+									batch := tea.Batch(cmds...)
+									return &batch
+								},
+							},
+							{
+								Name:      "ctf",
+								Path:      "/usr/bin/ctf",
+								Directory: false,
+								Owner:     "root",
+								Group:     "root",
+								Mode:      0711,
+								HelpText:  "Start the Honey Bear Honey Pot CTF game",
+								Exec: func(dir *Node, params []string) *tea.Cmd {
+									cmds := []tea.Cmd{}
+									cmds = append(cmds, tea.Cmd(func() tea.Msg { return SetRunningCmd("ctf") }))
+									cmds = append(cmds, tea.Cmd(func() tea.Msg {
+										time.Sleep(time.Millisecond * 100)
+										return ctf.Start()
+									}))
 									batch := tea.Batch(cmds...)
 									return &batch
 								},

--- a/internal/honeypot/model.go
+++ b/internal/honeypot/model.go
@@ -11,6 +11,7 @@ import (
 	"github.com/charmbracelet/log"
 	"github.com/google/shlex"
 	"github.com/mikeflynn/honeybearhoneypot/internal/honeypot/confetti"
+	"github.com/mikeflynn/honeybearhoneypot/internal/honeypot/ctf"
 	"github.com/mikeflynn/honeybearhoneypot/internal/honeypot/filesystem"
 	"github.com/mikeflynn/honeybearhoneypot/internal/honeypot/matrix"
 	"github.com/muesli/reflow/wordwrap"
@@ -39,6 +40,7 @@ type model struct {
 	viewportReady bool
 	confetti      tea.Model
 	matrix        tea.Model
+	ctf           tea.Model
 	helpText      string
 	events        map[string]time.Time
 	// Data
@@ -105,6 +107,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		m.confetti.Update(msg)
 		m.matrix.Update(msg)
+		m.ctf.Update(msg)
 
 		//cmds = append(cmds, viewport.Sync(m.viewport))
 	case filesystem.FileContentsMsg:
@@ -243,6 +246,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			//m.matrix.Init(),
 			cmd,
 		))
+	case "ctf":
+		np, cmd := m.ctf.Update(msg)
+		m.ctf = np
+		cmds = append(cmds, cmd)
 	default:
 		m.textInput, cmd = m.textInput.Update(msg)
 		cmds = append(cmds, cmd)
@@ -277,6 +284,9 @@ func (m model) View() string {
 		help = "Press 'q' to quit or any other key to make more confetti."
 	} else if m.runningCommand == "matrix" {
 		content = m.matrix.View()
+		help = "Press 'ctrl + c' to quit."
+	} else if m.runningCommand == "ctf" {
+		content = m.ctf.View()
 		help = "Press 'ctrl + c' to quit."
 	}
 

--- a/internal/honeypot/pot.go
+++ b/internal/honeypot/pot.go
@@ -21,9 +21,11 @@ import (
 	"github.com/charmbracelet/wish/activeterm"
 	"github.com/charmbracelet/wish/bubbletea"
 	"github.com/charmbracelet/wish/elapsed"
-	"github.com/charmbracelet/wish/logging"
-	"github.com/mikeflynn/honeybearhoneypot/internal/entity"
-	"github.com/mikeflynn/honeybearhoneypot/internal/honeypot/confetti"
+       "github.com/charmbracelet/wish/logging"
+       "github.com/mikeflynn/honeybearhoneypot/internal/entity"
+       "github.com/mikeflynn/honeybearhoneypot/internal/config"
+       "github.com/mikeflynn/honeybearhoneypot/internal/honeypot/confetti"
+	"github.com/mikeflynn/honeybearhoneypot/internal/honeypot/ctf"
 	"github.com/mikeflynn/honeybearhoneypot/internal/honeypot/embedded"
 	"github.com/mikeflynn/honeybearhoneypot/internal/honeypot/filesystem"
 	"github.com/mikeflynn/honeybearhoneypot/internal/honeypot/matrix"
@@ -284,8 +286,9 @@ func teaHandler(s ssh.Session) (tea.Model, []tea.ProgramOption) {
 		events: map[string]time.Time{
 			"session_start": time.Now(),
 		},
-		confetti:   confetti.InitialModel(),
-		matrix:     matrix.InitialModel(pty.Window.Width, pty.Window.Height),
+               confetti:   confetti.InitialModel(),
+               matrix:     matrix.InitialModel(pty.Window.Width, pty.Window.Height),
+               ctf:        ctf.InitialModel(convertTasks(config.Active.Tasks)),
 		output:     "",
 		helpText:   "Type 'help' to see some commands; Use up/down for history.",
 		historyIdx: 0,
@@ -295,6 +298,19 @@ func teaHandler(s ssh.Session) (tea.Model, []tea.ProgramOption) {
 	return m, []tea.ProgramOption{
 		//tea.WithAltScreen(),
 	}
+}
+
+func convertTasks(t []config.Task) []ctf.Task {
+       out := make([]ctf.Task, len(t))
+       for i, task := range t {
+               out[i] = ctf.Task{
+                       Name:        task.Name,
+                       Description: task.Description,
+                       Flag:        task.Flag,
+                       Points:      task.Points,
+               }
+       }
+       return out
 }
 
 func doTick() tea.Cmd {

--- a/main.go
+++ b/main.go
@@ -96,6 +96,8 @@ func setup() string {
 		appConfigDir,
 		entity.EventInitialization(),
 		entity.OptionInitialization(),
+		entity.CTFUserInit,
+		entity.CTFUserTaskInit,
 	)
 
 	return appConfigDir


### PR DESCRIPTION
## Summary
- add simple lipgloss styles for the CTF interface
- tweak the login flow so password input can be focused
- refine list settings and add instructions on the login screen

## Testing
- `go vet ./...` *(fails: access to proxy.golang.org forbidden)*
- `go build ./...` *(fails: access to proxy.golang.org forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6873461114288324ba1598e6e33dbf24