### PR TITLE
Improve CTF login navigation and UI

### DIFF
--- a/internal/entity/ctf_user.go
+++ b/internal/entity/ctf_user.go
@@ -89,3 +89,41 @@ func (u *CTFUser) CompleteTask(task string, points int) error {
 
 	return u.AddPoints(points)
 }
+
+// CompletedTasks returns a list of task names the user has finished.
+func (u *CTFUser) CompletedTasks() ([]string, error) {
+	rows, err := db.MakeQuery("SELECT task FROM ctf_user_tasks WHERE username=?", u.Username)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var tasks []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		tasks = append(tasks, name)
+	}
+	return tasks, nil
+}
+
+// Leaderboard returns the top users ordered by points.
+func Leaderboard(limit int) ([]CTFUser, error) {
+	rows, err := db.MakeQuery("SELECT username, points FROM ctf_users ORDER BY points DESC LIMIT ?", limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []CTFUser
+	for rows.Next() {
+		var u CTFUser
+		if err := rows.Scan(&u.Username, &u.Points); err != nil {
+			return nil, err
+		}
+		out = append(out, u)
+	}
+	return out, nil
+}

--- a/internal/entity/ctf_user.go
+++ b/internal/entity/ctf_user.go
@@ -127,14 +127,3 @@ func Leaderboard(limit int) ([]CTFUser, error) {
 	}
 	return out, nil
 }
-
-// TaskNameUsed checks if any user has previously completed a task with the given name.
-func TaskNameUsed(name string) (bool, error) {
-	rows, err := db.MakeQuery("SELECT 1 FROM ctf_user_tasks WHERE task=? LIMIT 1", name)
-	if err != nil {
-		return false, err
-	}
-	defer rows.Close()
-
-	return rows.Next(), nil
-}

--- a/internal/entity/ctf_user.go
+++ b/internal/entity/ctf_user.go
@@ -127,3 +127,14 @@ func Leaderboard(limit int) ([]CTFUser, error) {
 	}
 	return out, nil
 }
+
+// TaskNameUsed checks if any user has previously completed a task with the given name.
+func TaskNameUsed(name string) (bool, error) {
+	rows, err := db.MakeQuery("SELECT 1 FROM ctf_user_tasks WHERE task=? LIMIT 1", name)
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+
+	return rows.Next(), nil
+}

--- a/internal/honeypot/ctf/ctf.go
+++ b/internal/honeypot/ctf/ctf.go
@@ -17,11 +17,12 @@ func Start() tea.Msg { return startMsg{} }
 // startMsg is used to bootstrap the game from the filesystem command.
 type startMsg struct{}
 
-// quitMsg is sent when the user wants to exit the CTF without quitting the host program.
-type quitMsg struct{}
+// QuitMsg is sent when the user wants to exit the CTF without quitting the host
+// program.
+type QuitMsg struct{}
 
 // Quit returns a message that signals the parent model to close the CTF view.
-func Quit() tea.Msg { return quitMsg{} }
+func Quit() tea.Msg { return QuitMsg{} }
 
 // gameState indicates which screen we're showing.
 type gameState int
@@ -126,7 +127,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case stateAnswer:
 		return m.updateAnswer(msg)
 	case stateDone:
-		return m, func() tea.Msg { return quitMsg{} }
+		return m, func() tea.Msg { return QuitMsg{} }
 	}
 	return m, nil
 }
@@ -207,7 +208,7 @@ func (m Model) updateMenu(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		case "q", "ctrl+c":
 			m.state = stateDone
-			return m, func() tea.Msg { return quitMsg{} }
+			return m, func() tea.Msg { return QuitMsg{} }
 		}
 	}
 	m.list, cmd = m.list.Update(msg)

--- a/internal/honeypot/ctf/ctf.go
+++ b/internal/honeypot/ctf/ctf.go
@@ -136,18 +136,36 @@ func (m *Model) authenticate() tea.Cmd {
 }
 
 func (m Model) updateLogin(msg tea.Msg) (tea.Model, tea.Cmd) {
-	var cmd tea.Cmd
-	switch msg := msg.(type) {
-	case tea.KeyMsg:
-		switch msg.String() {
-		case "enter":
-			return m, m.authenticate()
-		}
-	}
-	m.usernameInput, cmd = m.usernameInput.Update(msg)
-	if m.usernameInput.Focused() {
-		return m, cmd
-	}
+        var cmd tea.Cmd
+        switch msg := msg.(type) {
+        case tea.KeyMsg:
+                switch msg.String() {
+                case "enter":
+                        return m, m.authenticate()
+                case "tab", "down":
+                        if m.usernameInput.Focused() {
+                                m.usernameInput.Blur()
+                                m.passwordInput.Focus()
+                        } else {
+                                m.passwordInput.Blur()
+                                m.usernameInput.Focus()
+                        }
+                        return m, nil
+                case "shift+tab", "up":
+                        if m.passwordInput.Focused() {
+                                m.passwordInput.Blur()
+                                m.usernameInput.Focus()
+                        } else {
+                                m.usernameInput.Blur()
+                                m.passwordInput.Focus()
+                        }
+                        return m, nil
+                }
+        }
+        m.usernameInput, cmd = m.usernameInput.Update(msg)
+        if m.usernameInput.Focused() {
+                return m, cmd
+        }
 	m.passwordInput, cmd = m.passwordInput.Update(msg)
 	return m, cmd
 }
@@ -202,15 +220,19 @@ func (m Model) updateAnswer(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) View() string {
-	titleStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("10")).Bold(true)
-	switch m.state {
-	case stateLogin:
-		return lipgloss.JoinVertical(lipgloss.Left,
-			titleStyle.Render("Honey Bear Honey Pot CTF"),
-			m.errMsg,
-			"username: "+m.usernameInput.View(),
-			"password: "+m.passwordInput.View(),
-		)
+        titleStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("10")).Bold(true)
+       welcome := lipgloss.NewStyle().Foreground(lipgloss.Color("7")).Render("Welcome to the Honey Bear Honey Pot CTF!\n" +
+               "Create an account by entering a new username and password or login with your existing credentials.")
+        switch m.state {
+        case stateLogin:
+                return lipgloss.JoinVertical(lipgloss.Left,
+                        titleStyle.Render("Honey Bear Honey Pot CTF"),
+                        welcome,
+                        m.list.View(),
+                        m.errMsg,
+                        "username: "+m.usernameInput.View(),
+                        "password: "+m.passwordInput.View(),
+                )
 	case stateMenu:
 		header := fmt.Sprintf("Honey Bear Honey Pot CTF - %s (%d pts)", m.user.Username, m.user.Points)
 		m.list.Title = header

--- a/internal/honeypot/filesystem/filesystem.go
+++ b/internal/honeypot/filesystem/filesystem.go
@@ -2,10 +2,12 @@ package filesystem
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/mikeflynn/honeybearhoneypot/internal/entity"
 	"github.com/mikeflynn/honeybearhoneypot/internal/honeypot/confetti"
 	"github.com/mikeflynn/honeybearhoneypot/internal/honeypot/ctf"
 	"github.com/mikeflynn/honeybearhoneypot/internal/honeypot/embedded"
@@ -434,6 +436,37 @@ func Initialize() {
 									}))
 									batch := tea.Batch(cmds...)
 									return &batch
+								},
+							},
+							{
+								Name:      "leaderboard",
+								Path:      "/usr/bin/leaderboard",
+								Directory: false,
+								Owner:     "root",
+								Group:     "root",
+								Mode:      0711,
+								HelpText:  "Show CTF leaderboard",
+								Exec: func(dir *Node, params []string) *tea.Cmd {
+									var cmd tea.Cmd
+									cmd = func() tea.Msg {
+										limit := 10
+										if len(params) > 0 {
+											if v, err := strconv.Atoi(params[0]); err == nil {
+												limit = v
+											}
+										}
+										board, err := entity.Leaderboard(limit)
+										if err != nil {
+											return OutputMsg(err.Error())
+										}
+										lines := []string{"Leaderboard:"}
+										for i, u := range board {
+											lines = append(lines, fmt.Sprintf("%d. %s - %d pts", i+1, u.Username, u.Points))
+										}
+										return OutputMsg(strings.Join(lines, "\n"))
+									}
+
+									return &cmd
 								},
 							},
 							{

--- a/internal/honeypot/filesystem/filesystem.go
+++ b/internal/honeypot/filesystem/filesystem.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/mikeflynn/honeybearhoneypot/internal/entity"
 	"github.com/mikeflynn/honeybearhoneypot/internal/honeypot/confetti"
 	"github.com/mikeflynn/honeybearhoneypot/internal/honeypot/ctf"
@@ -459,9 +460,17 @@ func Initialize() {
 										if err != nil {
 											return OutputMsg(err.Error())
 										}
-										lines := []string{"Leaderboard:"}
+										titleStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("5")).Bold(true)
+										rankStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("10")).Bold(true)
+										nameStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("12"))
+										ptsStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("11"))
+										lines := []string{titleStyle.Render("Honey Bear Honey Pot CTF Leaderboard")}
 										for i, u := range board {
-											lines = append(lines, fmt.Sprintf("%d. %s - %d pts", i+1, u.Username, u.Points))
+											line := fmt.Sprintf("%s %s - %s",
+												rankStyle.Render(fmt.Sprintf("%2d.", i+1)),
+												nameStyle.Render(u.Username),
+												ptsStyle.Render(fmt.Sprintf("%d pts", u.Points)))
+											lines = append(lines, line)
 										}
 										return OutputMsg(strings.Join(lines, "\n"))
 									}

--- a/internal/honeypot/filesystem/filesystem.go
+++ b/internal/honeypot/filesystem/filesystem.go
@@ -460,19 +460,33 @@ func Initialize() {
 										if err != nil {
 											return OutputMsg(err.Error())
 										}
-										titleStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("5")).Bold(true)
-										rankStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("10")).Bold(true)
+
+										title := lipgloss.NewStyle().Foreground(lipgloss.Color("5")).Bold(true)
 										nameStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("12"))
 										ptsStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("11"))
-										lines := []string{titleStyle.Render("Honey Bear Honey Pot CTF Leaderboard")}
+
+										lines := []string{title.Render("Honey Bear Honey Pot CTF Leaderboard")}
 										for i, u := range board {
+											col := "10"
+											switch i {
+											case 0:
+												col = "220"
+											case 1:
+												col = "250"
+											case 2:
+												col = "166"
+											}
+											rank := lipgloss.NewStyle().Foreground(lipgloss.Color(col)).Bold(true)
 											line := fmt.Sprintf("%s %s - %s",
-												rankStyle.Render(fmt.Sprintf("%2d.", i+1)),
+												rank.Render(fmt.Sprintf("%2d.", i+1)),
 												nameStyle.Render(u.Username),
 												ptsStyle.Render(fmt.Sprintf("%d pts", u.Points)))
 											lines = append(lines, line)
 										}
-										return OutputMsg(strings.Join(lines, "\n"))
+
+										content := lipgloss.JoinVertical(lipgloss.Left, lines...)
+										box := lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).Padding(1, 2)
+										return OutputMsg(box.Render(content))
 									}
 
 									return &cmd

--- a/internal/honeypot/model.go
+++ b/internal/honeypot/model.go
@@ -312,16 +312,3 @@ func (m model) EventTime(event string) *time.Time {
 func (m model) SetEventTime(event string) {
 	m.events[event] = time.Now()
 }
-
-func convertTasks(t []config.Task) []ctf.Task {
-	out := make([]ctf.Task, len(t))
-	for i, task := range t {
-		out[i] = ctf.Task{
-			Name:        task.Name,
-			Description: task.Description,
-			Flag:        task.Flag,
-			Points:      task.Points,
-		}
-	}
-	return out
-}

--- a/internal/honeypot/model.go
+++ b/internal/honeypot/model.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/log"
 	"github.com/google/shlex"
+	"github.com/mikeflynn/honeybearhoneypot/internal/config"
 	"github.com/mikeflynn/honeybearhoneypot/internal/honeypot/confetti"
 	"github.com/mikeflynn/honeybearhoneypot/internal/honeypot/ctf"
 	"github.com/mikeflynn/honeybearhoneypot/internal/honeypot/filesystem"
@@ -151,6 +152,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case ctf.QuitMsg:
 		m.viewport.SetContent("")
 		m.runningCommand = ""
+		m.ctf = ctf.InitialModel(convertTasks(config.Active.Tasks))
 		return m, nil
 	case tea.KeyMsg:
 		switch msg.String() {
@@ -309,4 +311,17 @@ func (m model) EventTime(event string) *time.Time {
 
 func (m model) SetEventTime(event string) {
 	m.events[event] = time.Now()
+}
+
+func convertTasks(t []config.Task) []ctf.Task {
+	out := make([]ctf.Task, len(t))
+	for i, task := range t {
+		out[i] = ctf.Task{
+			Name:        task.Name,
+			Description: task.Description,
+			Flag:        task.Flag,
+			Points:      task.Points,
+		}
+	}
+	return out
 }

--- a/internal/honeypot/model.go
+++ b/internal/honeypot/model.go
@@ -11,6 +11,7 @@ import (
 	"github.com/charmbracelet/log"
 	"github.com/google/shlex"
 	"github.com/mikeflynn/honeybearhoneypot/internal/honeypot/confetti"
+	"github.com/mikeflynn/honeybearhoneypot/internal/honeypot/ctf"
 	"github.com/mikeflynn/honeybearhoneypot/internal/honeypot/filesystem"
 	"github.com/mikeflynn/honeybearhoneypot/internal/honeypot/matrix"
 	"github.com/muesli/reflow/wordwrap"
@@ -147,7 +148,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		m.output += m.outputStyle.Render("\n")
-	case ctf.quitMsg:
+	case ctf.QuitMsg:
 		m.viewport.SetContent("")
 		m.runningCommand = ""
 		return m, nil

--- a/internal/honeypot/model.go
+++ b/internal/honeypot/model.go
@@ -147,6 +147,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		m.output += m.outputStyle.Render("\n")
+	case ctf.quitMsg:
+		m.viewport.SetContent("")
+		m.runningCommand = ""
+		return m, nil
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "enter":

--- a/internal/honeypot/pot.go
+++ b/internal/honeypot/pot.go
@@ -307,6 +307,9 @@ func convertTasks(t []config.Task) []ctf.Task {
 		if _, ok := seen[task.Name]; ok {
 			log.Fatalf("duplicate CTF task name: %s", task.Name)
 		}
+		if used, err := entity.TaskNameUsed(task.Name); err == nil && used {
+			log.Fatalf("duplicate CTF task name (database): %s", task.Name)
+		}
 		seen[task.Name] = struct{}{}
 		out = append(out, ctf.Task{
 			Name:        task.Name,

--- a/internal/honeypot/pot.go
+++ b/internal/honeypot/pot.go
@@ -21,10 +21,10 @@ import (
 	"github.com/charmbracelet/wish/activeterm"
 	"github.com/charmbracelet/wish/bubbletea"
 	"github.com/charmbracelet/wish/elapsed"
-       "github.com/charmbracelet/wish/logging"
-       "github.com/mikeflynn/honeybearhoneypot/internal/entity"
-       "github.com/mikeflynn/honeybearhoneypot/internal/config"
-       "github.com/mikeflynn/honeybearhoneypot/internal/honeypot/confetti"
+	"github.com/charmbracelet/wish/logging"
+	"github.com/mikeflynn/honeybearhoneypot/internal/config"
+	"github.com/mikeflynn/honeybearhoneypot/internal/entity"
+	"github.com/mikeflynn/honeybearhoneypot/internal/honeypot/confetti"
 	"github.com/mikeflynn/honeybearhoneypot/internal/honeypot/ctf"
 	"github.com/mikeflynn/honeybearhoneypot/internal/honeypot/embedded"
 	"github.com/mikeflynn/honeybearhoneypot/internal/honeypot/filesystem"
@@ -286,9 +286,9 @@ func teaHandler(s ssh.Session) (tea.Model, []tea.ProgramOption) {
 		events: map[string]time.Time{
 			"session_start": time.Now(),
 		},
-               confetti:   confetti.InitialModel(),
-               matrix:     matrix.InitialModel(pty.Window.Width, pty.Window.Height),
-               ctf:        ctf.InitialModel(convertTasks(config.Active.Tasks)),
+		confetti:   confetti.InitialModel(),
+		matrix:     matrix.InitialModel(pty.Window.Width, pty.Window.Height),
+		ctf:        ctf.InitialModel(convertTasks(config.Active.Tasks)),
 		output:     "",
 		helpText:   "Type 'help' to see some commands; Use up/down for history.",
 		historyIdx: 0,
@@ -301,16 +301,21 @@ func teaHandler(s ssh.Session) (tea.Model, []tea.ProgramOption) {
 }
 
 func convertTasks(t []config.Task) []ctf.Task {
-       out := make([]ctf.Task, len(t))
-       for i, task := range t {
-               out[i] = ctf.Task{
-                       Name:        task.Name,
-                       Description: task.Description,
-                       Flag:        task.Flag,
-                       Points:      task.Points,
-               }
-       }
-       return out
+	out := make([]ctf.Task, 0, len(t))
+	seen := map[string]struct{}{}
+	for _, task := range t {
+		if _, ok := seen[task.Name]; ok {
+			log.Fatalf("duplicate CTF task name: %s", task.Name)
+		}
+		seen[task.Name] = struct{}{}
+		out = append(out, ctf.Task{
+			Name:        task.Name,
+			Description: task.Description,
+			Flag:        task.Flag,
+			Points:      task.Points,
+		})
+	}
+	return out
 }
 
 func doTick() tea.Cmd {

--- a/internal/honeypot/pot.go
+++ b/internal/honeypot/pot.go
@@ -301,22 +301,14 @@ func teaHandler(s ssh.Session) (tea.Model, []tea.ProgramOption) {
 }
 
 func convertTasks(t []config.Task) []ctf.Task {
-	out := make([]ctf.Task, 0, len(t))
-	seen := map[string]struct{}{}
-	for _, task := range t {
-		if _, ok := seen[task.Name]; ok {
-			log.Fatalf("duplicate CTF task name: %s", task.Name)
-		}
-		if used, err := entity.TaskNameUsed(task.Name); err == nil && used {
-			log.Fatalf("duplicate CTF task name (database): %s", task.Name)
-		}
-		seen[task.Name] = struct{}{}
-		out = append(out, ctf.Task{
+	out := make([]ctf.Task, len(t))
+	for i, task := range t {
+		out[i] = ctf.Task{
 			Name:        task.Name,
 			Description: task.Description,
 			Flag:        task.Flag,
 			Points:      task.Points,
-		})
+		}
 	}
 	return out
 }


### PR DESCRIPTION
## Summary
- allow tab/arrow keys to move between username and password
- show an introductory message and task list before login

## Testing
- `go vet ./...` *(fails: forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6874153f04648324aae8e31e43705aeb