### PR TITLE
Improve CTF task UI

### DIFF
--- a/internal/honeypot/ctf/ctf.go
+++ b/internal/honeypot/ctf/ctf.go
@@ -294,7 +294,7 @@ func (m Model) View() string {
 			m.errMsg,
 		)
 	case stateAnswer:
-		desc := wordwrap.String(m.selectedTask.Description, uint(m.width-4))
+		desc := wordwrap.String(m.selectedTask.Description, m.width-4)
 		descStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("7"))
 		box := lipgloss.NewStyle().Border(lipgloss.NormalBorder()).Padding(1, 2)
 		content := lipgloss.JoinVertical(lipgloss.Left,


### PR DESCRIPTION
## Summary
- make the CTF listing page truncate task descriptions
- wrap long descriptions in the detail view
- style the answer input prompt
- show celebratory success messages and bold failures

## Testing
- `go vet ./...` *(fails: proxy.golang.org forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68752c0a55bc8324b746260e67058619