### PR TITLE
Use palette numbers instead of hex colors

### DIFF
--- a/internal/honeypot/confetti/confetti.go
+++ b/internal/honeypot/confetti/confetti.go
@@ -17,7 +17,8 @@ const (
 )
 
 var (
-	colors     = []string{"#a864fd", "#29cdff", "#78ff44", "#ff718d", "#fdff6a"}
+	// Using 256-color palette equivalents for broader terminal support.
+	colors     = []string{"141", "81", "119", "211", "228"}
 	characters = []string{"█", "▓", "▒", "░", "▄", "▀"}
 )
 

--- a/internal/honeypot/matrix/matrix.go
+++ b/internal/honeypot/matrix/matrix.go
@@ -10,19 +10,21 @@ import (
 )
 
 var (
-	matrixBg = lipgloss.Color("#111111")
+	// Approximated 256-color versions of the original palette for
+	// improved compatibility with terminals that don't support true color.
+	matrixBg = lipgloss.Color("233")
 
 	matrixPalettes = []lipgloss.Color{
-		lipgloss.Color("#000048"),
-		lipgloss.Color("#5e5e5e"),
-		lipgloss.Color("#5a5a5a"),
-		lipgloss.Color("#009a22"),
-		lipgloss.Color("#36ba01"),
-		lipgloss.Color("#002706"),
-		lipgloss.Color("#00ff00"),
-		lipgloss.Color("#009a22"),
-		lipgloss.Color("#00ff2b"),
-		lipgloss.Color("#36ba01"),
+		lipgloss.Color("17"),
+		lipgloss.Color("240"),
+		lipgloss.Color("240"),
+		lipgloss.Color("35"),
+		lipgloss.Color("76"),
+		lipgloss.Color("22"),
+		lipgloss.Color("46"),
+		lipgloss.Color("35"),
+		lipgloss.Color("47"),
+		lipgloss.Color("76"),
 	}
 
 	matrixGlyphs    = []rune("ABCDEFGHIJKLMNOPQRSTUVWXYZ12345678909qwertyuiopasdfghjklzxcvbnm")


### PR DESCRIPTION
## Summary
- update confetti palette with 256-color codes
- replace Matrix hex colors with 256-color equivalents

## Testing
- `go vet ./...` *(fails: module download blocked)*
- `go build ./...` *(fails: module download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687b1e8d42448324b2e4708195c04c56