### PR TITLE
Broadcasting to Active Honeypot Users

### DIFF
--- a/internal/gui/broadcast.go
+++ b/internal/gui/broadcast.go
@@ -1,8 +1,6 @@
 package gui
 
 import (
-	"fmt"
-
 	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/dialog"
 	"fyne.io/fyne/v2/theme"
@@ -20,15 +18,13 @@ func broadcastButton() *widget.Button {
 }
 
 func showBroadcastModal() {
-	title := fmt.Sprintf("Broadcast Actions — %d connected", honeypot.SessionCount())
+	knock := widget.NewButtonWithIcon("Knock", theme.QuestionIcon(), honeypot.ActionKnock)
+	notice := widget.NewButtonWithIcon("Notice", theme.WarningIcon(), honeypot.ActionSystemNotice)
+	join := widget.NewButtonWithIcon("Fake Join", theme.AccountIcon(), honeypot.ActionFakeJoin)
+	mtx := widget.NewButtonWithIcon("Matrix", theme.VisibilityIcon(), honeypot.ActionMatrix)
+	conf := widget.NewButtonWithIcon("Confetti", theme.ColorPaletteIcon(), honeypot.ActionConfetti)
 
-	knock := widget.NewButton("Knock Knock", func() { honeypot.ActionKnock() })
-	notice := widget.NewButton("System Notice", func() { honeypot.ActionSystemNotice() })
-	join := widget.NewButton("Fake Join", func() { honeypot.ActionFakeJoin() })
-	mtx := widget.NewButton("Matrix Storm", func() { honeypot.ActionMatrix() })
-	conf := widget.NewButton("Confetti", func() { honeypot.ActionConfetti() })
-
-	kick := widget.NewButton("Kick All", func() {
+	kick := widget.NewButtonWithIcon("Kick All", theme.LogoutIcon(), func() {
 		dialog.NewConfirm(
 			"Kick All Sessions",
 			"This will disconnect every currently logged-in user. Continue?",
@@ -42,6 +38,6 @@ func showBroadcastModal() {
 	})
 	kick.Importance = widget.DangerImportance
 
-	content := container.NewVBox(knock, notice, join, mtx, conf, kick)
-	dialog.NewCustom(title, "Close", content, w).Show()
+	grid := container.NewGridWithColumns(3, knock, notice, join, mtx, conf, kick)
+	dialog.NewCustom("Broadcast Actions", "Close", grid, w).Show()
 }

--- a/internal/gui/broadcast.go
+++ b/internal/gui/broadcast.go
@@ -1,0 +1,47 @@
+package gui
+
+import (
+	"fmt"
+
+	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/dialog"
+	"fyne.io/fyne/v2/theme"
+	"fyne.io/fyne/v2/widget"
+
+	"github.com/mikeflynn/honeybearhoneypot/internal/honeypot"
+)
+
+func broadcastButton() *widget.Button {
+	btn := widget.NewButtonWithIcon("", theme.MailSendIcon(), func() {
+		showBroadcastModal()
+	})
+	btn.Importance = widget.LowImportance
+	return btn
+}
+
+func showBroadcastModal() {
+	title := fmt.Sprintf("Broadcast Actions — %d connected", honeypot.SessionCount())
+
+	knock := widget.NewButton("Knock Knock", func() { honeypot.ActionKnock() })
+	notice := widget.NewButton("System Notice", func() { honeypot.ActionSystemNotice() })
+	join := widget.NewButton("Fake Join", func() { honeypot.ActionFakeJoin() })
+	mtx := widget.NewButton("Matrix Storm", func() { honeypot.ActionMatrix() })
+	conf := widget.NewButton("Confetti", func() { honeypot.ActionConfetti() })
+
+	kick := widget.NewButton("Kick All", func() {
+		dialog.NewConfirm(
+			"Kick All Sessions",
+			"This will disconnect every currently logged-in user. Continue?",
+			func(ok bool) {
+				if ok {
+					honeypot.ActionKickAll()
+				}
+			},
+			w,
+		).Show()
+	})
+	kick.Importance = widget.DangerImportance
+
+	content := container.NewVBox(knock, notice, join, mtx, conf, kick)
+	dialog.NewCustom(title, "Close", content, w).Show()
+}

--- a/internal/gui/window.go
+++ b/internal/gui/window.go
@@ -86,6 +86,7 @@ func StartGUI(fullscreen bool, overrideWidth, overrideHeight float32) {
 			layout.NewSpacer(),
 			container.NewVBox(
 				layout.NewSpacer(),
+				broadcastButton(),
 				aboutButton(),
 				getAdminButton(),
 			),

--- a/internal/honeypot/model.go
+++ b/internal/honeypot/model.go
@@ -70,31 +70,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	switch msg := msg.(type) {
 	case filesystem.TickMsg:
-		cmds := []tea.Cmd{}
-		if time.Since(*m.EventTime("session_start")) > 45*time.Second &&
-			m.EventTime("knock") == nil &&
-			m.runningCommand == "" &&
-			config.Active.NoFun == false &&
-			len(m.history) < 3 {
-			m.SetEventTime("knock")
-			cmds = append(
-				cmds,
-				tea.Cmd(func() tea.Msg {
-					return filesystem.ClearOutputMsg("")
-				}),
-				tea.Cmd(func() tea.Msg {
-					time.Sleep(time.Second * 1)
-					return filesystem.OutputMsg("Knock, knock, Neo.")
-				}),
-				tea.Cmd(func() tea.Msg {
-					time.Sleep(time.Second * 10)
-					return filesystem.OutputMsg("If you don't know what to do, type 'help' or 'ctf' to play a game.")
-				}),
-			)
-		}
-
-		cmds = append(cmds, doTick())
-		return m, tea.Batch(cmds...)
+		return m, doTick()
 	case tea.WindowSizeMsg:
 		m.height = msg.Height
 		m.width = msg.Width

--- a/internal/honeypot/pot.go
+++ b/internal/honeypot/pot.go
@@ -274,13 +274,14 @@ func StartHoneyPot(appConfigDir string) {
 			return ""
 		}),
 		wish.WithMiddleware(
-			bubbletea.Middleware(teaHandler),
+			bubbletea.MiddlewareWithProgramHandler(teaProgramHandler),
 			func(next ssh.Handler) ssh.Handler {
 				return func(s ssh.Session) {
 					addActiveUser(s.User())
 
 					next(s)
 
+					unregisterSession(s.Context().SessionID())
 					removeActiveUser(s.User())
 				}
 			},
@@ -407,6 +408,13 @@ func teaHandler(s ssh.Session) (tea.Model, []tea.ProgramOption) {
 	}
 
 	return m, bubbletea.MakeOptions(s)
+}
+
+func teaProgramHandler(s ssh.Session) *tea.Program {
+	m, opts := teaHandler(s)
+	p := tea.NewProgram(m, opts...)
+	registerSession(s.Context().SessionID(), p)
+	return p
 }
 
 func convertTasks(t []config.Task) []ctf.Task {

--- a/internal/honeypot/registry.go
+++ b/internal/honeypot/registry.go
@@ -68,9 +68,14 @@ func ActionMatrix() {
 	broadcast(filesystem.SetRunningCmd("matrix"), matrix.MatrixTick{})
 }
 
-// ActionConfetti flips every active session into confetti mode.
+// ActionConfetti fires a single burst of confetti on every active session
+// and auto-exits after a short window so the user doesn't have to dismiss it.
 func ActionConfetti() {
 	broadcast(filesystem.SetRunningCmd("confetti"), confetti.Burst())
+	go func() {
+		time.Sleep(5 * time.Second)
+		broadcast(filesystem.SetRunningCmd(""), filesystem.ClearOutputMsg(""))
+	}()
 }
 
 // ActionKickAll disconnects every active session.

--- a/internal/honeypot/registry.go
+++ b/internal/honeypot/registry.go
@@ -1,0 +1,79 @@
+package honeypot
+
+import (
+	"sync"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/mikeflynn/honeybearhoneypot/internal/honeypot/confetti"
+	"github.com/mikeflynn/honeybearhoneypot/internal/honeypot/filesystem"
+	"github.com/mikeflynn/honeybearhoneypot/internal/honeypot/matrix"
+)
+
+var (
+	sessionsMu sync.RWMutex
+	sessions   = map[string]*tea.Program{}
+)
+
+func registerSession(id string, p *tea.Program) {
+	sessionsMu.Lock()
+	sessions[id] = p
+	sessionsMu.Unlock()
+}
+
+func unregisterSession(id string) {
+	sessionsMu.Lock()
+	delete(sessions, id)
+	sessionsMu.Unlock()
+}
+
+// SessionCount returns the number of registered interactive sessions.
+func SessionCount() int {
+	sessionsMu.RLock()
+	defer sessionsMu.RUnlock()
+	return len(sessions)
+}
+
+func broadcast(msgs ...tea.Msg) {
+	sessionsMu.RLock()
+	defer sessionsMu.RUnlock()
+	for _, p := range sessions {
+		for _, msg := range msgs {
+			p.Send(msg)
+		}
+	}
+}
+
+// ActionKnock broadcasts the classic Matrix-style prompt to all sessions.
+func ActionKnock() {
+	broadcast(filesystem.OutputMsg("Knock, knock, Neo."))
+	go func() {
+		time.Sleep(10 * time.Second)
+		broadcast(filesystem.OutputMsg("If you don't know what to do, type 'help' or 'ctf' to play a game."))
+	}()
+}
+
+// ActionSystemNotice broadcasts a fake wall-style maintenance message.
+func ActionSystemNotice() {
+	broadcast(filesystem.OutputMsg("Broadcast message: System going down in 5 minutes for maintenance."))
+}
+
+// ActionFakeJoin broadcasts a fake "another user joined" line.
+func ActionFakeJoin() {
+	broadcast(filesystem.OutputMsg("user 'fozzie' has connected from 10.0.0.42"))
+}
+
+// ActionMatrix flips every active session into matrix mode.
+func ActionMatrix() {
+	broadcast(filesystem.SetRunningCmd("matrix"), matrix.MatrixTick{})
+}
+
+// ActionConfetti flips every active session into confetti mode.
+func ActionConfetti() {
+	broadcast(filesystem.SetRunningCmd("confetti"), confetti.Burst())
+}
+
+// ActionKickAll disconnects every active session.
+func ActionKickAll() {
+	broadcast(tea.Quit())
+}


### PR DESCRIPTION
`internal/honeypot/registry.go` (new) — session map keyed by SSH session ID, broadcast helper, and the six action functions (ActionKnock, ActionSystemNotice, ActionFakeJoin, ActionMatrix, ActionConfetti, ActionKickAll).

`internal/honeypot/pot.go` — switched to bubbletea.MiddlewareWithProgramHandler, added teaProgramHandler that creates the *tea.Program and registers it. Wrap middleware now also calls unregisterSession on session end.

`internal/honeypot/model.go` — removed the auto knock-knock branch from the tick handler; the manual button is now the only trigger.

`internal/gui/broadcast.go` (new) — broadcastButton() (mail-send icon) opens a custom dialog with the six action buttons. Kick All has a confirm dialog and DangerImportance styling.

`internal/gui/window.go` — broadcast button added to the VBox directly above the help icon.

Resolves #58 